### PR TITLE
Bug in _harmonize_inputs_to_dict

### DIFF
--- a/src/optimagic/visualization/history_plots.py
+++ b/src/optimagic/visualization/history_plots.py
@@ -172,10 +172,7 @@ def _harmonize_inputs_to_dict(results, names):
     if not isinstance(names, list) and names is not None:
         names = [names]
 
-    if isinstance(results, OptimizeResult):
-        results = [results]
-
-    if isinstance(results, (str, Path)):
+    if isinstance(results, (OptimizeResult, str, Path)):
         results = [results]
 
     if names is not None and len(names) != len(results):

--- a/src/optimagic/visualization/history_plots.py
+++ b/src/optimagic/visualization/history_plots.py
@@ -175,6 +175,9 @@ def _harmonize_inputs_to_dict(results, names):
     if isinstance(results, OptimizeResult):
         results = [results]
 
+    if isinstance(results, (str, Path)):
+        results = [results]
+
     if names is not None and len(names) != len(results):
         raise ValueError("len(results) needs to be equal to len(names).")
 

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -177,8 +177,18 @@ def test_harmonize_inputs_to_dict_invalid_names():
     with pytest.raises(ValueError):
         _harmonize_inputs_to_dict(results=results, names=names)
 
-def test_harmonize_inputs_to_dict_with_log_file_name():
-    log_options = om.SQLiteLogOptions("test_log.db", if_database_exists=om.ExistenceStrategy.REPLACE,)
-    res = minimize(fun=lambda x: x @ x, params=np.arange(5), algorithm="scipy_lbfgsb", logging=log_options,)
-    assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {"0": "test_log.db"}
 
+def test_harmonize_inputs_to_dict_with_log_file_name():
+    log_options = om.SQLiteLogOptions(
+        "test_log.db",
+        if_database_exists=om.ExistenceStrategy.REPLACE,
+    )
+    res = minimize(
+        fun=lambda x: x @ x,
+        params=np.arange(5),
+        algorithm="scipy_lbfgsb",
+        logging=log_options,
+    )
+    assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {
+        "0": "test_log.db"
+    }

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -183,8 +183,12 @@ def test_harmonize_inputs_to_dict_with_log_file_name():
         "test_log.db",
         if_database_exists=om.ExistenceStrategy.REPLACE,
     )
-    minimize(fun=lambda x: x @ x,params=np.arange(5),
-        algorithm="scipy_lbfgsb",logging=log_options,)
+    minimize(
+        fun=lambda x: x @ x,
+        params=np.arange(5),
+        algorithm="scipy_lbfgsb",
+        logging=log_options,
+    )
     assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {
         "0": "test_log.db"
     }

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -1,4 +1,5 @@
 import itertools
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -126,6 +127,7 @@ def test_criterion_plot_different_input_types():
     criterion_plot(results, stack_multistart=True)
     criterion_plot(results, monotone=True, stack_multistart=True)
     criterion_plot(results, show_exploration=True)
+    criterion_plot("test.db")
 
 
 def test_criterion_plot_wrong_inputs():
@@ -178,17 +180,10 @@ def test_harmonize_inputs_to_dict_invalid_names():
         _harmonize_inputs_to_dict(results=results, names=names)
 
 
-def test_harmonize_inputs_to_dict_with_log_file_name():
-    log_options = om.SQLiteLogOptions(
-        "test_log.db",
-        if_database_exists=om.ExistenceStrategy.REPLACE,
-    )
-    minimize(
-        fun=lambda x: x @ x,
-        params=np.arange(5),
-        algorithm="scipy_lbfgsb",
-        logging=log_options,
-    )
-    assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {
-        "0": "test_log.db"
-    }
+def test_harmonize_inputs_to_dict_str_input():
+    assert _harmonize_inputs_to_dict(results="test.db", names=None) == {"0": "test.db"}
+
+
+def test_harmonize_inputs_to_dict_path_input():
+    path = Path("test.db")
+    assert _harmonize_inputs_to_dict(results=path, names=None) == {"0": path}

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -183,12 +183,8 @@ def test_harmonize_inputs_to_dict_with_log_file_name():
         "test_log.db",
         if_database_exists=om.ExistenceStrategy.REPLACE,
     )
-    res = minimize(
-        fun=lambda x: x @ x,
-        params=np.arange(5),
-        algorithm="scipy_lbfgsb",
-        logging=log_options,
-    )
+    minimize(fun=lambda x: x @ x,params=np.arange(5),
+        algorithm="scipy_lbfgsb",logging=log_options,)
     assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {
         "0": "test_log.db"
     }

--- a/tests/optimagic/visualization/test_history_plots.py
+++ b/tests/optimagic/visualization/test_history_plots.py
@@ -176,3 +176,9 @@ def test_harmonize_inputs_to_dict_invalid_names():
     names = ["a", "b"]
     with pytest.raises(ValueError):
         _harmonize_inputs_to_dict(results=results, names=names)
+
+def test_harmonize_inputs_to_dict_with_log_file_name():
+    log_options = om.SQLiteLogOptions("test_log.db", if_database_exists=om.ExistenceStrategy.REPLACE,)
+    res = minimize(fun=lambda x: x @ x, params=np.arange(5), algorithm="scipy_lbfgsb", logging=log_options,)
+    assert _harmonize_inputs_to_dict(results="test_log.db", names=None) == {"0": "test_log.db"}
+


### PR DESCRIPTION
## Bug description:
While reading the docs on 'How to use logging',
fig = om.criterion_plot("my_log.db") does not produce a figure instead a FileNotFoundError is shown.
This is because input of type str is not handled in _harmonize_inputs_to_dict.
### How to reproduce the error
```
om.minimize(
    fun= lambda x : x@x,
    params=np.arange(5),
    algorithm="scipy_lbfgsb",
    logging=om.SQLiteLogOptions(
    "my_log.db", if_database_exists=om.ExistenceStrategy.REPLACE
),)
fig = om.criterion_plot("test_log.db")
fig.show()
```
Traceback
<details>
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
Cell In[11], line 1
----> 1 fig = om.criterion_plot("my_log.db")
      2 fig.show(renderer="png")

File ~/checkouts/readthedocs.org/user_builds/optimagic/conda/latest/lib/python3.10/site-packages/optimagic/visualization/history_plots.py:75, in criterion_plot(results, names, max_evaluations, template, palette, stack_multistart, monotone, show_exploration)
     71     _data = _extract_plotting_data_from_results_object(
     72         res, stack_multistart, show_exploration, plot_name="criterion_plot"
     73     )
     74 elif isinstance(res, (str, Path)):
---> 75     _data = _extract_plotting_data_from_database(
     76         res, stack_multistart, show_exploration
     77     )
     78 else:
     79     msg = "results must be (or contain) an OptimizeResult or a path to a log"

File ~/checkouts/readthedocs.org/user_builds/optimagic/conda/latest/lib/python3.10/site-packages/optimagic/visualization/history_plots.py:390, in _extract_plotting_data_from_database(res, stack_multistart, show_exploration)
    368 def _extract_plotting_data_from_database(res, stack_multistart, show_exploration):
    369     """Extract data for plotting from database.
    370 
    371     Args:
   (...)
    388 
    389     """
--> 390     reader = LogReader.from_options(SQLiteLogOptions(res))
    391     _problem_table = reader.problem_df
    393     direction = _problem_table["direction"].tolist()[-1]

File ~/checkouts/readthedocs.org/user_builds/optimagic/conda/latest/lib/python3.10/site-packages/optimagic/logging/logger.py:95, in LogReader.from_options(cls, log_options)
     88 if log_reader_class is None:
     89     raise ValueError(
     90         f"No LogReader implementation found for type "
     91         f"{type(log_options)}. Available option types: "
     92         f"\n {list(_LOG_OPTION_LOG_READER_REGISTRY.keys())}"
     93     )
---> 95 return log_reader_class._create(log_options)

File ~/checkouts/readthedocs.org/user_builds/optimagic/conda/latest/lib/python3.10/site-packages/optimagic/logging/logger.py:473, in SQLiteLogReader._create(cls, log_options)
    461 @classmethod
    462 def _create(cls, log_options: SQLiteLogOptions) -> SQLiteLogReader:
    463     """Create an instance of SQLiteLogReader using the provided log options.
    464 
    465     Args:
   (...)
    471 
    472     """
--> 473     return cls(log_options.path)

File ~/checkouts/readthedocs.org/user_builds/optimagic/conda/latest/lib/python3.10/site-packages/optimagic/logging/logger.py:452, in SQLiteLogReader.__init__(self, path)
    450 def __init__(self, path: str | Path):
    451     if not os.path.exists(path):
--> 452         raise FileNotFoundError(f"No file found at {path=}")
    454     log_options = SQLiteLogOptions(
    455         path, fast_logging=True, if_database_exists=ExistenceStrategy.EXTEND
    456     )
    457     self._iteration_store = IterationStore(log_options)

FileNotFoundError: No file found at path='t'
</details>

##  Solution
Handle input of type (str | Path) in _harmonize_inputs_to_dict in optimagic /visualization/history_plots.py using 
``` 
if isinstance(results, (str, Path)): 
        results = [results] 
```
## With fix 
plot is generated correctly
![image](https://github.com/user-attachments/assets/e69a82f9-1bde-4a06-b0dc-0c7ce6ffda0c)


