### PR TITLE
Convert to array in order to allow for Boolean indexing.

### DIFF
--- a/src/optimagic/parameters/check_constraints.py
+++ b/src/optimagic/parameters/check_constraints.py
@@ -241,7 +241,7 @@ def check_fixes_and_bounds(constr_info, transformations, parnames):
     if is_invalid.any():
         info = pd.DataFrame(
             {
-                "names": parnames[is_invalid],
+                "names": np.array(parnames)[is_invalid],
                 "lower_bounds": constr_info["lower_bounds"][is_invalid],
                 "upper_bounds": constr_info["upper_bounds"][is_invalid],
             }


### PR DESCRIPTION
Another triviality. Since `parnames` is a list and `is_invalid` Boolean array, no useful message comes out without the change.