### PR TITLE
MAINT: using intersphinx-registry

### DIFF
--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -41,4 +41,5 @@ dependencies:
       - types-jinja2  # dev, tests
       - sqlalchemy-stubs  # dev, tests
       - sphinxcontrib-mermaid  # dev, tests, docs
+      - intersphinx-registry  # docs
       - fides==0.7.4  # dev, tests

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,8 @@ import datetime as dt
 import os
 from importlib.metadata import version
 
+from intersphinx_registry import get_intersphinx_mapping
+
 year = dt.datetime.now().year
 
 author = "Janos Gabler"
@@ -88,11 +90,9 @@ extlinks = {
     "gh": ("https://github.com/optimagic-dev/optimagic/pulls/%s", "#"),
 }
 
-intersphinx_mapping = {
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "python": ("https://docs.python.org/3.12", None),
-}
+intersphinx_mapping = get_intersphinx_mapping(
+    packages={"numpy", "scipy", "pandas", "python"}
+)
 
 linkcheck_ignore = [
     r"https://tinyurl\.com/*.",

--- a/environment.yml
+++ b/environment.yml
@@ -30,6 +30,7 @@ dependencies:
   - sphinx-design  # docs
   - sphinx-panels  # docs
   - sphinxcontrib-bibtex  # docs
+  - intersphinx-registry  # docs
   - seaborn  # dev, tests
   - mypy=1.14.1  # dev, tests
   - pyyaml  # dev, tests


### PR DESCRIPTION
Found the broken numpy doc link in `intersphinx_mapping`, so used [intersphinx-registry](https://pypi.org/project/intersphinx-registry/) to avoid needing to update these links in the future. Also added `scipy` in the list of packages. Please LMK if this is a good change and/or anything needs to be changed.

Thank you :)