### PR TITLE
scipy_bfgs params

### DIFF
--- a/docs/source/algorithms.md
+++ b/docs/source/algorithms.md
@@ -191,7 +191,7 @@ install optimagic.
       is compared to the gradient tolerance to determine convergence. Default is infinite which means that
       the largest entry of the gradient vector is compared to the gradient tolerance.
     - **display** (bool): 
-	    Set to True to print convergence messages. Default is True.
+	    Set to True to print convergence messages. Default is False.
       - scipy name: **disp**
     - **convergence_xtol_rel** (float):
       Relative tolerance for `x`. Terminate successfully if step size is less than `xk * xrtol` where `xk` is the current parameter vector. Default is 1e-5.

--- a/docs/source/algorithms.md
+++ b/docs/source/algorithms.md
@@ -190,7 +190,21 @@ install optimagic.
     - **norm** (float): Order of the vector norm that is used to calculate the gradient's "score" that
       is compared to the gradient tolerance to determine convergence. Default is infinite which means that
       the largest entry of the gradient vector is compared to the gradient tolerance.
-
+    - **display** (bool): 
+	    Set to True to print convergence messages. Default is True.
+      - scipy name: **disp**
+    - **convergence_xtol_rel** (float):
+      Relative tolerance for `x`. Terminate successfully if step size is less than `xk * xrtol` where `xk` is the current parameter vector. Default is 1e-5.
+      - scipy name: **xrtol**
+    - **armijo_condition** (float):
+      Parameter for Armijo condition rule. Default is 1e-4.
+      Ensures $f(x_k+\alpha p_k) \le f(x_k) \;+$ **armijo_condition**$\,\cdot\,\alpha\,\nabla f(x_k)^\top p_k$, so each step yields at least a fraction **armijo_condition** of the predicted decrease.
+      smaller ⇒ more aggressive steps, larger ⇒ more conservative ones 
+      - scipy name: **c1**
+    - **curvature_condition** (float):
+      Parameter for curvature condition rule. Default is 0.9. Ensures $\nabla f(x_k+\alpha p_k)^\top p_k \ge\;$ **curvature_condition**$\,\cdot\,\nabla f(x_k)^\top p_k$, so the new slope along $p_k$ isn’t too negative.
+      - smaller ⇒ stricter curvature reduction (smaller steps), larger ⇒ looser (bigger steps)
+      - scipy name: **c2**
 ```
 
 ```{eval-rst}

--- a/src/optimagic/logging/logger.py
+++ b/src/optimagic/logging/logger.py
@@ -190,7 +190,7 @@ class LogReader(Generic[_LogOptionsType], ABC):
         # For numpy arrays with ndim = 0, tolist() returns a scalar, which violates the
         # type hinting list[Any] from above. As history["time"] is always a list, this
         # case is safe to ignore.
-        history["time"] = times.tolist()  # type: ignore[assignment]
+        history["time"] = times.tolist()
 
         df = pd.DataFrame(history)
         df = df.merge(

--- a/src/optimagic/optimization/history.py
+++ b/src/optimagic/optimization/history.py
@@ -409,7 +409,7 @@ def _get_flat_param_names(param: PyTree) -> list[str]:
     if fast_path:
         # Mypy raises an error here because .tolist() returns a str for zero-dimensional
         # arrays, but the fast path is only taken for 1d arrays, so it can be ignored.
-        return np.arange(param.size).astype(str).tolist()  # type: ignore[return-value]
+        return np.arange(param.size).astype(str).tolist()
 
     registry = get_registry(extended=True)
     return leaf_names(param, registry=registry)
@@ -530,7 +530,7 @@ def _get_batch_starts_and_stops(batch_ids: list[int]) -> tuple[list[int], list[i
     """
     ids_arr = np.array(batch_ids, dtype=np.int64)
     indices = np.where(ids_arr[:-1] != ids_arr[1:])[0] + 1
-    list_indices: list[int] = indices.tolist()  # type: ignore[assignment]
+    list_indices: list[int] = indices.tolist()
     starts = [0, *list_indices]
     stops = [*starts[1:], len(batch_ids)]
     return starts, stops

--- a/src/optimagic/optimizers/scipy_optimizers.py
+++ b/src/optimagic/optimizers/scipy_optimizers.py
@@ -267,6 +267,10 @@ class ScipyBFGS(Algorithm):
     convergence_gtol_abs: NonNegativeFloat = CONVERGENCE_GTOL_ABS
     stopping_maxiter: PositiveInt = STOPPING_MAXITER
     norm: NonNegativeFloat = np.inf
+    convergence_xtol_rel: NonNegativeFloat = CONVERGENCE_XTOL_REL
+    display: bool = False
+    armijo_condition: NonNegativeFloat = 1e-4
+    curvature_condition: NonNegativeFloat = 0.9
 
     def _solve_internal_problem(
         self, problem: InternalOptimizationProblem, x0: NDArray[np.float64]
@@ -275,6 +279,10 @@ class ScipyBFGS(Algorithm):
             "gtol": self.convergence_gtol_abs,
             "maxiter": self.stopping_maxiter,
             "norm": self.norm,
+            "xrtol": self.convergence_xtol_rel,
+            "disp": self.display,
+            "c1": self.armijo_condition,
+            "c2": self.curvature_condition,
         }
         raw_res = scipy.optimize.minimize(
             fun=problem.fun_and_jac, x0=x0, method="BFGS", jac=True, options=options


### PR DESCRIPTION
Added the following parameters from SciPy's BFGS optimizer, which where not exposed in the optimagic implementation:   

 - **display** (bool): 
	    Set to True to print convergence messages. Default is False.
      - scipy name: **disp**
- **convergence_xtol_rel** (float):
  Relative tolerance for `x`. Terminate successfully if step size is less than `xk * xrtol` where `xk` is the current parameter vector. Default is 1e-5.
      - scipy name: **xrtol**
- **armijo_condition** (float):
  Parameter for Armijo condition rule. Default is 1e-4.
      - smaller ⇒ more aggressive steps, larger ⇒ more conservative ones 
      - scipy name: **c1**
- **curvature_condition** (float):
  Parameter for curvature condition rule. Default is 0.9. 
      - smaller ⇒ stricter curvature reduction (smaller steps), larger ⇒ looser (bigger steps)
      - scipy name: **c2**