### PR TITLE
Fix the too strict checking of batch evaluator literals for multistart.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,45 @@ chronological order. We follow [semantic versioning](https://semver.org/) and al
 releases are available on [Anaconda.org](https://anaconda.org/optimagic-dev/optimagic).
 
 
+## 0.5.2
+
+This minor release includes several bug fixes and small improvements. Many contributions in this release were made by Google Summer of Code (GSoC) 2025 applicants, with @gauravmanmode and @spline2hg being the accepted contributors.
+
+- {gh}`605` Enhances batch evaluator checking and processing, introduces the internal
+  `BatchEvaluatorLiteral` literal, and updates CHANGES.md ({ghuser}`janosg`,
+  {ghuser}`timmens`).
+- {gh}`598` Fixes and adds links to GitHub in the documentation ({ghuser}`hamogu`).
+- {gh}`594` Refines newly added optimizer wrappers ({ghuser}`janosg`).
+- {gh}`589` Rewrites the algorithm selection pre-commit hook in pure Python to address
+  issues with bash scripts on Windows ({ghuser}`timmens`).
+- {gh}`586` and {gh}`592` Ensure the SciPy `disp` parameter is exposed for the following
+  SciPy algorithms: slsqp, neldermead, powell, conjugate_gradient, newton_cg, cobyla,
+  truncated_newton, trust_constr ({ghuser}`sefmef`, {ghuser}`TimBerti`).
+- {gh}`585` Exposes all parameters of [SciPy's
+  BFGS](https://docs.scipy.org/doc/scipy/reference/optimize.minimize-bfgs.html)
+  optimizer in optimagic ({ghuser}`TimBerti`).
+- {gh}`582` Adds support for handling infinite gradients during optimization
+  ({ghuser}`Aziz-Shameem`).
+- {gh}`579` Implements a wrapper for the PSO optimizer from the
+  [nevergrad](https://github.com/facebookresearch/nevergrad) package ({ghuser}`r3kste`).
+- {gh}`578` Integrates the `intersphinx-registry` package into the documentation for
+  automatic linking to up-to-date external documentation
+  ({ghuser}`Schefflera-Arboricola`).
+- {gh}`572` and {gh}`573` Fix bugs in error handling for parameter selector processing
+  and constraints checking ({ghuser}`hmgaudecker`).
+- {gh}`570` Adds a how-to guide for adding algorithms to optimagic and improves internal
+  documentation ({ghuser}`janosg`).
+- {gh}`569` Implements a threading batch evaluator ({ghuser}`spline2hg`).
+- {gh}`568` Introduces an initial wrapper for the migrad optimizer from the
+  [iminuit](https://github.com/scikit-hep/iminuit) package ({ghuser}`spline2hg`).
+- {gh}`567` Makes the `fun` argument optional when `fun_and_jac` is provided
+  ({ghuser}`gauravmanmode`).
+- {gh}`563` Fixes a bug in input harmonization for history plotting
+  ({ghuser}`gauravmanmode`).
+- {gh}`552` Refactors and extends the `History` class, removing the internal
+  `HistoryArrays` class ({ghuser}`timmens`).
+
+
 ## 0.5.1
 
 This is a minor release that introduces the new algorithm selection tool and several

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,9 @@ releases are available on [Anaconda.org](https://anaconda.org/optimagic-dev/opti
 
 ## 0.5.2
 
-This minor release includes several bug fixes and small improvements. Many contributions in this release were made by Google Summer of Code (GSoC) 2025 applicants, with @gauravmanmode and @spline2hg being the accepted contributors.
+This minor release includes several bug fixes and small improvements. Many contributions
+in this release were made by Google Summer of Code (GSoC) 2025 applicants, with
+@gauravmanmode and @spline2hg being the accepted contributors.
 
 - {gh}`605` Enhances batch evaluator checking and processing, introduces the internal
   `BatchEvaluatorLiteral` literal, and updates CHANGES.md ({ghuser}`janosg`,

--- a/src/optimagic/batch_evaluators.py
+++ b/src/optimagic/batch_evaluators.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Literal, TypeVar, cast
 
 from optimagic.config import DEFAULT_N_CORES as N_CORES
 from optimagic.decorators import catch, unpack
-from optimagic.typing import BatchEvaluator, ErrorHandling
+from optimagic.typing import BatchEvaluator, BatchEvaluatorLiteral, ErrorHandling
 
 T = TypeVar("T")
 
@@ -260,8 +260,7 @@ def _check_inputs(
 
 
 def process_batch_evaluator(
-    batch_evaluator: Literal["joblib", "pathos", "threading"]
-    | BatchEvaluator = "joblib",
+    batch_evaluator: BatchEvaluatorLiteral | BatchEvaluator = "joblib",
 ) -> BatchEvaluator:
     batch_evaluator = "joblib" if batch_evaluator is None else batch_evaluator
     if callable(batch_evaluator):
@@ -275,8 +274,8 @@ def process_batch_evaluator(
             out = cast(BatchEvaluator, threading_batch_evaluator)
         else:
             raise ValueError(
-                "Invalid batch evaluator requested. Currently only 'pathos' and "
-                "'joblib' are supported."
+                "Invalid batch evaluator requested. Currently only 'pathos', 'joblib', "
+                "and 'threading' are supported."
             )
     else:
         raise TypeError("batch_evaluator must be a callable or string.")

--- a/src/optimagic/batch_evaluators.py
+++ b/src/optimagic/batch_evaluators.py
@@ -17,6 +17,7 @@ except ImportError:
 import threading
 from typing import Any, Callable, Literal, TypeVar, cast
 
+from optimagic import deprecations
 from optimagic.config import DEFAULT_N_CORES as N_CORES
 from optimagic.decorators import catch, unpack
 from optimagic.typing import BatchEvaluator, BatchEvaluatorLiteral, ErrorHandling
@@ -262,7 +263,10 @@ def _check_inputs(
 def process_batch_evaluator(
     batch_evaluator: BatchEvaluatorLiteral | BatchEvaluator = "joblib",
 ) -> BatchEvaluator:
-    batch_evaluator = "joblib" if batch_evaluator is None else batch_evaluator
+    if batch_evaluator is None:
+        deprecations.throw_none_valued_batch_evaluator_warning()
+        batch_evaluator = "joblib"
+
     if callable(batch_evaluator):
         out = batch_evaluator
     elif isinstance(batch_evaluator, str):

--- a/src/optimagic/deprecations.py
+++ b/src/optimagic/deprecations.py
@@ -183,6 +183,15 @@ def throw_dict_access_future_warning(attribute, obj_name):
     warnings.warn(msg, FutureWarning)
 
 
+def throw_none_valued_batch_evaluator_warning():
+    msg = (
+        "Passing `None` as the `batch_evaluator` is deprecated and will be "
+        "removed in optimagic version 0.6.0. Please use the string 'joblib' instead to "
+        "use the joblib batch evaluator by default."
+    )
+    warnings.warn(msg, FutureWarning)
+
+
 def replace_and_warn_about_deprecated_algo_options(algo_options):
     if not isinstance(algo_options, dict):
         return algo_options

--- a/src/optimagic/differentiation/derivatives.py
+++ b/src/optimagic/differentiation/derivatives.py
@@ -23,7 +23,7 @@ from optimagic.differentiation.richardson_extrapolation import richardson_extrap
 from optimagic.parameters.block_trees import hessian_to_block_tree, matrix_to_block_tree
 from optimagic.parameters.bounds import Bounds, get_internal_bounds, pre_process_bounds
 from optimagic.parameters.tree_registry import get_registry
-from optimagic.typing import PyTree
+from optimagic.typing import BatchEvaluatorLiteral, PyTree
 
 
 @dataclass(frozen=True)
@@ -95,7 +95,7 @@ def first_derivative(
     f0: PyTree | None = None,
     n_cores: int = DEFAULT_N_CORES,
     error_handling: Literal["continue", "raise", "raise_strict"] = "continue",
-    batch_evaluator: Literal["joblib", "pathos"] | Callable = "joblib",
+    batch_evaluator: BatchEvaluatorLiteral | Callable = "joblib",
     unpacker: Callable[[Any], PyTree] | None = None,
     # deprecated
     lower_bounds: PyTree | None = None,
@@ -400,7 +400,7 @@ def second_derivative(
     f0: PyTree | None = None,
     n_cores: int = DEFAULT_N_CORES,
     error_handling: Literal["continue", "raise", "raise_strict"] = "continue",
-    batch_evaluator: Literal["joblib", "pathos"] | Callable = "joblib",
+    batch_evaluator: BatchEvaluatorLiteral | Callable = "joblib",
     unpacker: Callable[[Any], PyTree] | None = None,
     # deprecated
     lower_bounds: PyTree | None = None,

--- a/src/optimagic/differentiation/numdiff_options.py
+++ b/src/optimagic/differentiation/numdiff_options.py
@@ -6,6 +6,7 @@ from typing_extensions import NotRequired
 
 from optimagic.config import DEFAULT_N_CORES
 from optimagic.exceptions import InvalidNumdiffOptionsError
+from optimagic.typing import BatchEvaluatorLiteral
 
 
 @dataclass(frozen=True)
@@ -37,7 +38,7 @@ class NumdiffOptions:
     scaling_factor: float = 1
     min_steps: float | None = None
     n_cores: int = DEFAULT_N_CORES
-    batch_evaluator: Literal["joblib", "pathos"] | Callable = "joblib"  # type: ignore
+    batch_evaluator: BatchEvaluatorLiteral | Callable = "joblib"  # type: ignore
 
     def __post_init__(self) -> None:
         _validate_attribute_types_and_values(self)
@@ -51,7 +52,7 @@ class NumdiffOptionsDict(TypedDict):
     scaling_factor: NotRequired[float]
     min_steps: NotRequired[float | None]
     n_cores: NotRequired[int]
-    batch_evaluator: NotRequired[Literal["joblib", "pathos"] | Callable]  # type: ignore
+    batch_evaluator: NotRequired[BatchEvaluatorLiteral | Callable]  # type: ignore
 
 
 def pre_process_numdiff_options(

--- a/src/optimagic/differentiation/numdiff_options.py
+++ b/src/optimagic/differentiation/numdiff_options.py
@@ -4,6 +4,7 @@ from typing import Callable, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
+from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.config import DEFAULT_N_CORES
 from optimagic.exceptions import InvalidNumdiffOptionsError
 from optimagic.typing import BatchEvaluatorLiteral
@@ -22,8 +23,8 @@ class NumdiffOptions:
         min_steps: The minimum step size to use for numerical differentiation. If None,
             the default minimum step size will be used.
         n_cores: The number of cores to use for numerical differentiation.
-        batch_evaluator: The batch evaluator to use for numerical differentiation. Can
-            be "joblib" or "pathos", or a custom function.
+        batch_evaluator: The evaluator to use for batch evaluation. Allowed are
+            "joblib", "pathos", and "threading", or a custom callable.
 
     Raises:
         InvalidNumdiffError: If the numdiff options cannot be processed, e.g. because
@@ -140,14 +141,12 @@ def _validate_attribute_types_and_values(options: NumdiffOptions) -> None:
             "must be an integer greater than 0."
         )
 
-    if not callable(options.batch_evaluator) and options.batch_evaluator not in {
-        "joblib",
-        "pathos",
-    }:
+    try:
+        process_batch_evaluator(options.batch_evaluator)
+    except Exception as e:
         raise InvalidNumdiffOptionsError(
-            f"Invalid numdiff `batch_evaluator`: {options.batch_evaluator}. Batch "
-            "evaluator must be a callable or one of 'joblib', 'pathos'."
-        )
+            f"Invalid batch evaluator: {options.batch_evaluator}."
+        ) from e
 
 
 class NumdiffPurpose(str, Enum):

--- a/src/optimagic/optimization/multistart_options.py
+++ b/src/optimagic/optimization/multistart_options.py
@@ -45,8 +45,8 @@ class MultistartOptions:
             for convergence. Determines the maximum relative distance two parameter
             vecctors can have to be considered equal. Defaults to 0.01.
         n_cores: The number of cores to use for parallelization. Defaults to 1.
-        batch_evaluator: The evaluator to use for batch evaluation. Allowed are "joblib"
-            and "pathos", or a custom callable.
+        batch_evaluator: The evaluator to use for batch evaluation. Allowed are
+            "joblib", "pathos", and "threading", or a custom callable.
         batch_size: The batch size for batch evaluation. Must be larger than n_cores
             or None.
         seed: The seed for the random number generator.

--- a/src/optimagic/optimization/multistart_options.py
+++ b/src/optimagic/optimization/multistart_options.py
@@ -9,7 +9,7 @@ from typing_extensions import NotRequired
 from optimagic.batch_evaluators import process_batch_evaluator
 from optimagic.deprecations import replace_and_warn_about_deprecated_multistart_options
 from optimagic.exceptions import InvalidMultistartError
-from optimagic.typing import BatchEvaluator, PyTree
+from optimagic.typing import BatchEvaluator, BatchEvaluatorLiteral, PyTree
 
 # ======================================================================================
 # Public Options
@@ -71,7 +71,7 @@ class MultistartOptions:
     convergence_xtol_rel: float | None = None
     convergence_max_discoveries: int = 2
     n_cores: int = 1
-    batch_evaluator: Literal["joblib", "pathos"] | BatchEvaluator = "joblib"
+    batch_evaluator: BatchEvaluatorLiteral | BatchEvaluator = "joblib"
     batch_size: int | None = None
     seed: int | np.random.Generator | None = None
     error_handling: Literal["raise", "continue"] | None = None
@@ -100,7 +100,7 @@ class MultistartOptionsDict(TypedDict):
     convergence_xtol_rel: NotRequired[float | None]
     convergence_max_discoveries: NotRequired[int]
     n_cores: NotRequired[int]
-    batch_evaluator: NotRequired[Literal["joblib", "pathos"] | BatchEvaluator]
+    batch_evaluator: NotRequired[BatchEvaluatorLiteral | BatchEvaluator]
     batch_size: NotRequired[int | None]
     seed: NotRequired[int | np.random.Generator | None]
     error_handling: NotRequired[Literal["raise", "continue"] | None]
@@ -247,14 +247,12 @@ def _validate_attribute_types_and_values(options: MultistartOptions) -> None:
             "must be a positive integer."
         )
 
-    if not callable(options.batch_evaluator) and options.batch_evaluator not in (
-        "joblib",
-        "pathos",
-    ):
+    try:
+        process_batch_evaluator(options.batch_evaluator)
+    except Exception as e:
         raise InvalidMultistartError(
-            f"Invalid batch evaluator: {options.batch_evaluator}. Batch evaluator "
-            "must be a Callable or one of 'joblib' or 'pathos'."
-        )
+            f"Invalid batch evaluator: {options.batch_evaluator}."
+        ) from e
 
     if options.batch_size is not None and (
         not isinstance(options.batch_size, int) or options.batch_size < options.n_cores

--- a/src/optimagic/optimizers/scipy_optimizers.py
+++ b/src/optimagic/optimizers/scipy_optimizers.py
@@ -74,6 +74,7 @@ from optimagic.parameters.nonlinear_constraints import (
 from optimagic.typing import (
     AggregationLevel,
     BatchEvaluator,
+    BatchEvaluatorLiteral,
     NegativeFloat,
     NonNegativeFloat,
     NonNegativeInt,
@@ -810,7 +811,7 @@ class ScipyBrute(Algorithm):
     n_grid_points: PositiveInt = 20
     polishing_function: Callable | None = None
     n_cores: PositiveInt = 1
-    batch_evaluator: Literal["joblib", "pathos"] | BatchEvaluator = "joblib"
+    batch_evaluator: BatchEvaluatorLiteral | BatchEvaluator = "joblib"
 
     def _solve_internal_problem(
         self, problem: InternalOptimizationProblem, x0: NDArray[np.float64]
@@ -890,7 +891,7 @@ class ScipyDifferentialEvolution(Algorithm):
     ) = "latinhypercube"
     convergence_ftol_abs: NonNegativeFloat = CONVERGENCE_SECOND_BEST_FTOL_ABS
     n_cores: PositiveInt = 1
-    batch_evaluator: Literal["joblib", "pathos"] | BatchEvaluator = "joblib"
+    batch_evaluator: BatchEvaluatorLiteral | BatchEvaluator = "joblib"
 
     def _solve_internal_problem(
         self, problem: InternalOptimizationProblem, x0: NDArray[np.float64]

--- a/src/optimagic/typing.py
+++ b/src/optimagic/typing.py
@@ -122,7 +122,7 @@ NegativeFloat = Annotated[float, Lt(0)]
 GtOneFloat = Annotated[float, Gt(1)]
 YesNoBool = Literal["yes", "no"] | bool
 DirectionLiteral = Literal["minimize", "maximize"]
-BatchEvaluatorLiteral = Literal["joblib", "pathos"]
+BatchEvaluatorLiteral = Literal["joblib", "pathos", "threading"]
 ErrorHandlingLiteral = Literal["raise", "continue"]
 
 

--- a/tests/optimagic/differentiation/test_numdiff_options.py
+++ b/tests/optimagic/differentiation/test_numdiff_options.py
@@ -80,6 +80,6 @@ def test_numdiff_options_invalid_n_cores():
 
 def test_numdiff_options_invalid_batch_evaluator():
     with pytest.raises(
-        InvalidNumdiffOptionsError, match="Invalid numdiff `batch_evaluator`:"
+        InvalidNumdiffOptionsError, match="Invalid batch evaluator: invalid"
     ):
         NumdiffOptions(batch_evaluator="invalid")

--- a/tests/optimagic/optimization/test_with_multistart.py
+++ b/tests/optimagic/optimization/test_with_multistart.py
@@ -310,3 +310,15 @@ def test_with_ackley_using_dict_options():
             "convergence_max_discoveries": 10,
         },
     )
+
+
+@pytest.mark.slow
+def test_with_batch_evaluator(params):
+    options = om.MultistartOptions(batch_evaluator="threading")
+
+    minimize(
+        fun=sos_scalar,
+        params=params,
+        algorithm="scipy_lbfgsb",
+        multistart=options,
+    )


### PR DESCRIPTION
Closes #604 