### PR TITLE
Ensure `exploration_results` is a numpy array

### DIFF
--- a/src/optimagic/optimization/optimize_result.py
+++ b/src/optimagic/optimization/optimize_result.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from optimagic import deprecations
 from optimagic.logging.logger import LogReader
@@ -218,7 +219,7 @@ class MultistartInfo:
     start_parameters: list[PyTree]
     local_optima: list[OptimizeResult]
     exploration_sample: list[PyTree]
-    exploration_results: list[float]
+    exploration_results: NDArray[np.float64]
 
     def __getitem__(self, key):
         deprecations.throw_dict_access_future_warning(key, obj_name=type(self).__name__)

--- a/src/optimagic/optimization/process_results.py
+++ b/src/optimagic/optimization/process_results.py
@@ -156,10 +156,11 @@ def _process_multistart_info(
 
     sample = [converter.params_from_internal(x) for x in info["exploration_sample"]]
 
+    # info["exploration_results"] is a numpy array
     if extra_fields.direction == Direction.MINIMIZE:
         exploration_res = info["exploration_results"]
     else:
-        exploration_res = [-res for res in info["exploration_results"]]
+        exploration_res = -info["exploration_results"]
 
     return MultistartInfo(
         start_parameters=starts,

--- a/tests/optimagic/optimization/test_with_multistart.py
+++ b/tests/optimagic/optimization/test_with_multistart.py
@@ -80,8 +80,9 @@ def test_multistart_optimization_with_sum_of_squares_at_defaults(
     assert hasattr(res, "multistart_info")
     ms_info = res.multistart_info
     assert len(ms_info.exploration_sample) == 400
+    assert isinstance(ms_info.exploration_results, np.ndarray)
     assert len(ms_info.exploration_results) == 400
-    assert all(isinstance(entry, float) for entry in ms_info.exploration_results)
+    assert ms_info.exploration_results.dtype == np.float64
     assert all(isinstance(entry, OptimizeResult) for entry in ms_info.local_optima)
     assert all(isinstance(entry, pd.DataFrame) for entry in ms_info.start_parameters)
     assert np.allclose(res.fun, 0)


### PR DESCRIPTION
This PR ensures that `exploration_results` in `MultistartInfo` is always a numpy array.

### Summary

1. Fix a case where exploration_results is converted to a list.
2. Test that it is a numpy array of dtype `np.float64`.
3. Change type hint of exploration_results from `list[float]` to `NDArray[np.float64]`.

### Possible Changes
I would like to get feedback on whether the following changes should be included.

- Use a less strict check for dtype of `exploration_results`. For example, a [subdtype](https://numpy.org/doc/stable/reference/generated/numpy.issubdtype.html) of `np.floating`
- Add a check to assert that `exploration_results` is positive for `minimize` and negative for `maximize`.

