### PR TITLE
Add pre-commit hook that checks mypy version consistency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,16 @@ repos:
         require_serial: true
   - repo: local
     hooks:
+      - id: check-mypy-versions
+        name: verify that pre-commits and dev env use the same mypy version
+        entry: python .tools/check_mypy_versions.py
+        language: python
+        always_run: true
+        require_serial: true
+        additional_dependencies:
+          - pyyaml
+  - repo: local
+    hooks:
       - id: update-algo-selection-code
         name: update algo selection code
         entry: python .tools/update_algo_selection_hook.py

--- a/.tools/check_mypy_versions.py
+++ b/.tools/check_mypy_versions.py
@@ -1,0 +1,38 @@
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _get_mypy_version_from_precommit_config() -> str:
+    config = yaml.safe_load(Path(".pre-commit-config.yaml").read_text())
+    mypy_config = [
+        hook
+        for hook in config["repos"]
+        if hook["repo"] == "https://github.com/pre-commit/mirrors-mypy"
+    ][0]
+    return re.search(r"v([\d.]+)", mypy_config["rev"]).group(1)  # Remove "v" prefix
+
+
+def _get_mypy_version_from_conda_environment() -> str:
+    config = yaml.safe_load(Path("environment.yml").read_text())
+    mypy_line = [dep for dep in config["dependencies"] if "mypy" in dep][0]
+    return re.search(r"mypy=([\d.]+)", mypy_line).group(1)
+
+
+def main():
+    v_precommit = _get_mypy_version_from_precommit_config()
+    v_conda = _get_mypy_version_from_conda_environment()
+    if v_precommit != v_conda:
+        print(
+            f"Error: Mypy versions do not match:\n"
+            f"  Pre-commit config: {v_precommit}\n"
+            f"  Conda environment: {v_conda}\n"
+        )
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In this PR we add a local pre-commit hooks that checks whether the mypy version in the pre-commit config and the (conda) environment are the same.

This is supposed to help us keep these two versions the same, as otherwise we cannot ensure consistent results of calling mypy. 