### PR TITLE
Add note about __future__ import

### DIFF
--- a/docs/source/how_to/how_to_document_optimizers.md
+++ b/docs/source/how_to/how_to_document_optimizers.md
@@ -160,6 +160,16 @@ more memory but may converge faster for some problems.
 - **Explain performance implications** when they matter
 - **Use proper type annotations** that match the parameter's constraints
 
+> **Note:** If your optimizer module uses type hints (e.g., `PositiveInt`,
+> `NonNegativeInt`), include the following at the top of your optimizer module:
+
+```python
+from __future__ import annotations
+```
+
+Without this, type hints such as `PositiveInt` may appear decomposed in the
+documentation (e.g., as `Annotated[int, Gt(gt=0)]`).
+
 ### Step 4: Integrate into `algorithms.md`
 
 The final step is integrating your documented algorithm into the main documentation.

--- a/docs/source/how_to/how_to_document_optimizers.md
+++ b/docs/source/how_to/how_to_document_optimizers.md
@@ -160,15 +160,20 @@ more memory but may converge faster for some problems.
 - **Explain performance implications** when they matter
 - **Use proper type annotations** that match the parameter's constraints
 
-> **Note:** If your optimizer module uses type hints (e.g., `PositiveInt`,
-> `NonNegativeInt`), include the following at the top of your optimizer module:
+```{eval-rst}
 
-```python
-from __future__ import annotations
+.. warning::
+    If your optimizer module uses type hints (e.g., ``PositiveInt``,
+    ``NonNegativeInt``), include the following at the top of your optimizer module:
+
+    .. code-block:: python
+
+        from __future__ import annotations
+
+    Without this, type hints such as ``PositiveInt`` may appear decomposed in the
+    documentation (e.g., as ``Annotated[int, Gt(gt=0)]``).
+
 ```
-
-Without this, type hints such as `PositiveInt` may appear decomposed in the
-documentation (e.g., as `Annotated[int, Gt(gt=0)]`).
 
 ### Step 4: Integrate into `algorithms.md`
 


### PR DESCRIPTION
Added a note in the `how_to_document_optimizers` guide about using `from __future__ import annotations` to ensure type hints are rendered correctly in Sphinx.
