### PR TITLE
pin petsc4py to <= 3.23.4,  failing test python 3.11

### DIFF
--- a/.tools/envs/testenv-linux.yml
+++ b/.tools/envs/testenv-linux.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - petsc4py
+  - petsc4py<=3.23.4
   - jax
   - cyipopt>=1.4.0  # dev, tests
   - pygmo>=2.19.0  # dev, tests, docs

--- a/.tools/update_envs.py
+++ b/.tools/update_envs.py
@@ -29,7 +29,8 @@ def main() -> None:
     ## linux
     test_env_linux = deepcopy(test_env)
     test_env_linux.insert(_insert_idx, "  - jax")
-    test_env_linux.insert(_insert_idx, "  - petsc4py")
+    # pinned petsc4py due to failing test on python 3.11 , revert later
+    test_env_linux.insert(_insert_idx, "  - petsc4py<=3.23.4")
 
     ## test environment others
     test_env_others = deepcopy(test_env)


### PR DESCRIPTION
pin petsc4py to <= 3.23.4,
Failing test on python 3.11 with error
```
E   [0] Unable to find requested Tao type pounders
petsc4py/PETSc/TAO.pyx:190: Error
```