### PR TITLE
Update CHANGES.md for 0.5.4 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,12 +5,31 @@ chronological order. We follow [semantic versioning](https://semver.org/) and al
 releases are available on [Anaconda.org](https://anaconda.org/optimagic-dev/optimagic).
 
 
-## Unreleased
+## 0.5.4
 
-- Allows a `FixedConstraint` pinning selected elements to any value in `[0, 1)` (with
-  their sum strictly less than one) to coexist with a `ProbabilityConstraint` on the
-  same parameters. The fixed entries are held at their values and the remaining free
-  entries are optimised on a simplex summing to `1 - sum(fixed values)`.
+This release allows **fixed entries in probability constraints**, adds support for
+**tranquilo 0.1.1**, and contains a major internal **refactoring of the constraints
+pipeline** towards typed constraint objects. The development environment was migrated
+from conda/micromamba to **pixi**.
+
+- {gh}`688` Refactors constraint resolution to work on typed constraint objects
+  ({ghuser}`janosg`).
+- {gh}`687` Converts constraint dictionaries to typed constraint objects during
+  processing ({ghuser}`janosg`).
+- {gh}`686` Adds characterization tests for the constraint pipeline
+  ({ghuser}`janosg`).
+- {gh}`683` Allows a `FixedConstraint` pinning selected elements to any value in
+  `[0, 1)` (with their sum strictly less than one) to coexist with a
+  `ProbabilityConstraint` on the same parameters. The fixed entries are held at their
+  values and the remaining free entries are optimised on a simplex summing to
+  `1 - sum(fixed values)` ({ghuser}`hmgaudecker`).
+- {gh}`678` Fixes grammar in the style guide ({ghuser}`abelaba`).
+- {gh}`676` Cleans up pre-commit hooks and switches from pre-commit to prek
+  ({ghuser}`timmens`).
+- {gh}`674` Migrates the development environment from conda/micromamba to pixi
+  ({ghuser}`timmens`).
+- {gh}`671` Updates the README ({ghuser}`timmens`).
+- {gh}`661` Adds support for tranquilo 0.1.1 ({ghuser}`timmens`).
 
 
 ## 0.5.3


### PR DESCRIPTION
Turns the `Unreleased` section of CHANGES.md into the `0.5.4` section, covering all PRs merged since v0.5.3 (#661, #671, #674, #676, #678, #683, #686, #687, #688). Pre-commit.ci autoupdates are omitted, consistent with previous releases.