### PR TITLE
Docs: explain AggregationLevel / problem types

### DIFF
--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -15,8 +15,7 @@ optionally `@om.mark.scalar`). That mark changes:
 1. **Which specialized optimizers you can use** (for example pounders for least-squares,
    or BHHH for likelihood).
 1. **How error penalties and derivatives are interpreted** when something goes wrong
-   (see {ref}`how-to-errors`) or when a scalar optimizer is used on a specialized
-   problem.
+   (see {ref}`how-to-errors`).
 
 Any marked function can still be solved with a normal scalar optimizer; optimagic
 aggregates the vector output when needed (sum of squares for least-squares, sum of

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -12,9 +12,9 @@ optionally `@om.mark.scalar`). That mark changes:
 
 1. **What your function should return** (a single number vs a vector of contributions or
    residuals).
-2. **Which specialized optimizers you can use** (for example pounders for least-squares,
+1. **Which specialized optimizers you can use** (for example pounders for least-squares,
    or BHHH for likelihood).
-3. **How error penalties and derivatives are interpreted** when something goes wrong
+1. **How error penalties and derivatives are interpreted** when something goes wrong
    (see {ref}`how-to-errors`) or when a scalar optimizer is used on a specialized
    problem.
 

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -14,12 +14,18 @@ optionally `@om.mark.scalar`). That mark changes:
    residuals).
 1. **Which specialized optimizers you can use** (for example pounders for least-squares,
    or BHHH for likelihood).
+<<<<<<< HEAD
 1. **How error penalties and derivatives are interpreted** when something goes wrong or
    when a scalar optimizer is used on a specialized problem.
+=======
+3. **How error penalties and derivatives are interpreted** when something goes wrong
+   (see {ref}`how-to-errors`) or when a scalar optimizer is used on a specialized
+   problem.
+>>>>>>> 04ce067 (docs: address review on AggregationLevel explanation)
 
-The same marked function can often still be solved with a normal scalar optimizer;
-optimagic aggregates the vector output when needed (sum of squares for least-squares,
-sum of contributions for likelihood).
+Any marked function can still be solved with a normal scalar optimizer; optimagic
+aggregates the vector output when needed (sum of squares for least-squares, sum of
+contributions for likelihood).
 
 ## Scalar problems
 
@@ -78,8 +84,7 @@ maximum likelihood; optimagic flips the sign internally for the solver. If you p
 Do **not** return only the summed scalar log-likelihood if you want likelihood-specific
 optimizers — they need the contributions.
 
-For estimation workflows built on likelihood functions, see also the estimagic
-tutorials.
+For estimation workflows built on likelihood functions, see also {ref}`estimagic`.
 
 ## How this relates to `AggregationLevel`
 

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -2,19 +2,19 @@
 
 # Problem types (`AggregationLevel`)
 
-optimagic can optimize three kinds of objective functions: **scalar**, **least-squares**,
-and **likelihood**. Internally these are represented by
+optimagic can optimize three kinds of objective functions: **scalar**,
+**least-squares**, and **likelihood**. Internally these are represented by
 {class}`~optimagic.typing.AggregationLevel`.
 
 You tell optimagic which kind you have by marking the objective function with a
-decorator from `optimagic.mark` (`@om.mark.least_squares`, `@om.mark.likelihood`,
-or optionally `@om.mark.scalar`). That mark changes:
+decorator from `optimagic.mark` (`@om.mark.least_squares`, `@om.mark.likelihood`, or
+optionally `@om.mark.scalar`). That mark changes:
 
 1. **What your function should return** (a single number vs a vector of contributions or
    residuals).
-2. **Which specialized optimizers you can use** (for example pounders for least-squares,
+1. **Which specialized optimizers you can use** (for example pounders for least-squares,
    or BHHH for likelihood).
-3. **How error penalties and derivatives are interpreted** when something goes wrong or
+1. **How error penalties and derivatives are interpreted** when something goes wrong or
    when a scalar optimizer is used on a specialized problem.
 
 The same marked function can often still be solved with a normal scalar optimizer;
@@ -53,8 +53,8 @@ def ls_sphere(params):
 ```
 
 **Why mark it?** Specialized least-squares solvers can use the residual structure and
-are often much faster than treating $f(x)=\sum_i r_i(x)^2$ as a black-box scalar. If
-you only return the scalar sum of squares, those solvers cannot be used.
+are often much faster than treating $f(x)=\sum_i r_i(x)^2$ as a black-box scalar. If you
+only return the scalar sum of squares, those solvers cannot be used.
 
 See {ref}`how-to-fun` for a short usage example.
 
@@ -83,11 +83,11 @@ tutorials.
 
 ## How this relates to `AggregationLevel`
 
-| Problem | Decorator | Typical return | `AggregationLevel` |
-|---------|-----------|----------------|--------------------|
-| Scalar | none or `@om.mark.scalar` | `float` | `SCALAR` |
-| Least-squares | `@om.mark.least_squares` | residual vector | `LEAST_SQUARES` |
-| Likelihood | `@om.mark.likelihood` | contribution vector | `LIKELIHOOD` |
+| Problem       | Decorator                 | Typical return      | `AggregationLevel` |
+| ------------- | ------------------------- | ------------------- | ------------------ |
+| Scalar        | none or `@om.mark.scalar` | `float`             | `SCALAR`           |
+| Least-squares | `@om.mark.least_squares`  | residual vector     | `LEAST_SQUARES`    |
+| Likelihood    | `@om.mark.likelihood`     | contribution vector | `LIKELIHOOD`       |
 
 Optimizers are also tagged with a `solver_type` of the same enum (see
 {ref}`internal_optimizer_interface`). Matching the mark on your function to the solver

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -13,15 +13,14 @@ optionally `@om.mark.scalar`). That mark changes:
 1. **What your function should return** (a single number vs a vector of contributions or
    residuals).
 1. **Which specialized optimizers you can use** (for example pounders for least-squares,
-   or BHHH for likelihood).
-<<<<<<< HEAD
+   or BHHH for likelihood). \<<\<<\<<< HEAD
 1. **How error penalties and derivatives are interpreted** when something goes wrong or
-   when a scalar optimizer is used on a specialized problem.
-=======
-3. **How error penalties and derivatives are interpreted** when something goes wrong
+   when a scalar optimizer is used on a specialized problem. =======
+1. **How error penalties and derivatives are interpreted** when something goes wrong
    (see {ref}`how-to-errors`) or when a scalar optimizer is used on a specialized
    problem.
->>>>>>> 04ce067 (docs: address review on AggregationLevel explanation)
+
+> > > > > > > 04ce067 (docs: address review on AggregationLevel explanation)
 
 Any marked function can still be solved with a normal scalar optimizer; optimagic
 aggregates the vector output when needed (sum of squares for least-squares, sum of

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -1,0 +1,94 @@
+(aggregation_level)=
+
+# Problem types (`AggregationLevel`)
+
+optimagic can optimize three kinds of objective functions: **scalar**, **least-squares**,
+and **likelihood**. Internally these are represented by
+{class}`~optimagic.typing.AggregationLevel`.
+
+You tell optimagic which kind you have by marking the objective function with a
+decorator from `optimagic.mark` (`@om.mark.least_squares`, `@om.mark.likelihood`,
+or optionally `@om.mark.scalar`). That mark changes:
+
+1. **What your function should return** (a single number vs a vector of contributions or
+   residuals).
+2. **Which specialized optimizers you can use** (for example pounders for least-squares,
+   or BHHH for likelihood).
+3. **How error penalties and derivatives are interpreted** when something goes wrong or
+   when a scalar optimizer is used on a specialized problem.
+
+The same marked function can often still be solved with a normal scalar optimizer;
+optimagic aggregates the vector output when needed (sum of squares for least-squares,
+sum of contributions for likelihood).
+
+## Scalar problems
+
+This is the default. Your function returns a **single number** — the value to minimize
+(or maximize).
+
+```python
+import optimagic as om
+import numpy as np
+
+
+# @om.mark.scalar is optional; unmarked functions are treated as scalar
+def sphere(params):
+    return params @ params
+
+
+om.minimize(sphere, params=np.arange(3), algorithm="scipy_lbfgsb")
+```
+
+Use this whenever you do not have least-squares or likelihood structure to exploit.
+
+## Least-squares problems
+
+Mark the function with `@om.mark.least_squares` and return the **residuals** (a vector
+or pytree), **not** the sum of squared residuals.
+
+```python
+@om.mark.least_squares
+def ls_sphere(params):
+    return params  # residuals; optimagic forms sum of squares if needed
+```
+
+**Why mark it?** Specialized least-squares solvers can use the residual structure and
+are often much faster than treating $f(x)=\sum_i r_i(x)^2$ as a black-box scalar. If
+you only return the scalar sum of squares, those solvers cannot be used.
+
+See {ref}`how-to-fun` for a short usage example.
+
+## Likelihood problems
+
+Mark the function with `@om.mark.likelihood` and return a **vector (or pytree) of
+per-observation log-likelihood contributions**, not a single summed log-likelihood.
+
+```python
+@om.mark.likelihood
+def loglike_contributions(params):
+    # return one log-density value per observation (an array), not their sum
+    ...
+```
+
+**Sign / maximize vs minimize:** return the actual log-likelihood contributions (the
+quantities you would sum to get $\ell(\theta)$). Prefer {func}`~optimagic.maximize` for
+maximum likelihood; optimagic flips the sign internally for the solver. If you prefer
+{func}`~optimagic.minimize`, return **negative** log-likelihood contributions instead.
+
+Do **not** return only the summed scalar log-likelihood if you want likelihood-specific
+optimizers — they need the contributions.
+
+For estimation workflows built on likelihood functions, see also the estimagic
+tutorials.
+
+## How this relates to `AggregationLevel`
+
+| Problem | Decorator | Typical return | `AggregationLevel` |
+|---------|-----------|----------------|--------------------|
+| Scalar | none or `@om.mark.scalar` | `float` | `SCALAR` |
+| Least-squares | `@om.mark.least_squares` | residual vector | `LEAST_SQUARES` |
+| Likelihood | `@om.mark.likelihood` | contribution vector | `LIKELIHOOD` |
+
+Optimizers are also tagged with a `solver_type` of the same enum (see
+{ref}`internal_optimizer_interface`). Matching the mark on your function to the solver
+type is what lets optimagic pick the right internal representation.

--- a/docs/source/explanation/aggregation_level.md
+++ b/docs/source/explanation/aggregation_level.md
@@ -12,15 +12,11 @@ optionally `@om.mark.scalar`). That mark changes:
 
 1. **What your function should return** (a single number vs a vector of contributions or
    residuals).
-1. **Which specialized optimizers you can use** (for example pounders for least-squares,
-   or BHHH for likelihood). \<<\<<\<<< HEAD
-1. **How error penalties and derivatives are interpreted** when something goes wrong or
-   when a scalar optimizer is used on a specialized problem. =======
-1. **How error penalties and derivatives are interpreted** when something goes wrong
+2. **Which specialized optimizers you can use** (for example pounders for least-squares,
+   or BHHH for likelihood).
+3. **How error penalties and derivatives are interpreted** when something goes wrong
    (see {ref}`how-to-errors`) or when a scalar optimizer is used on a specialized
    problem.
-
-> > > > > > > 04ce067 (docs: address review on AggregationLevel explanation)
 
 Any marked function can still be solved with a normal scalar optimizer; optimagic
 aggregates the vector output when needed (sum of squares for least-squares, sum of

--- a/docs/source/explanation/index.md
+++ b/docs/source/explanation/index.md
@@ -7,6 +7,7 @@ optimagic. It is completely optional and not necessary if you are just starting 
 ---
 maxdepth: 1
 ---
+aggregation_level
 implementation_of_constraints
 internal_optimizers
 why_optimization_is_hard.ipynb

--- a/docs/source/how_to/how_to_criterion_function.ipynb
+++ b/docs/source/how_to/how_to_criterion_function.ipynb
@@ -121,7 +121,11 @@
     "Many estimation problems have a least-squares structure. If so, specialized optimizers that exploit this structure can be much faster than standard optimizers. The `sphere` function from above is the simplest possible least-squarse problem you could imagine: the least-squares residuals are just the params. \n",
     "\n",
     "To use least-squares optimizers in optimagic, you need to mark your function with \n",
-    "a decorator and return the least-squares residuals instead of the aggregated function value. "
+    "a decorator and return the least-squares residuals instead of the aggregated function value.\n",
+    "\n",
+    "For a short explanation of scalar, least-squares, and likelihood problem types\n",
+    "(`AggregationLevel`) and what each decorator expects, see\n",
+    "{ref}`aggregation_level`.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Adds an Explanation page for scalar, least-squares, and likelihood problem types (`AggregationLevel`)
- Clarifies what each `@om.mark.*` decorator expects as a return value, and maximize vs minimize for likelihood
- Links the new page from the “How to write objective functions” guide

Closes #595

## Test plan
- [ ] Build/docs preview: Explanation → Problem types (`AggregationLevel`)
- [ ] Confirm link from How to write objective functions (least-squares section)
- [ ] Check that the page answers the questions raised in #595 (purpose of marks, return types, likelihood sign)